### PR TITLE
Allow extensions in all OpenApi structures

### DIFF
--- a/lib/open_api_spex/components.ex
+++ b/lib/open_api_spex/components.ex
@@ -25,7 +25,8 @@ defmodule OpenApiSpex.Components do
     :headers,
     :securitySchemes,
     :links,
-    :callbacks
+    :callbacks,
+    :extensions
   ]
 
   @type schemas_map :: %{String.t() => Schema.t() | Reference.t()}
@@ -47,6 +48,7 @@ defmodule OpenApiSpex.Components do
           headers: %{String.t() => Header.t() | Reference.t()} | nil,
           securitySchemes: %{String.t() => SecurityScheme.t() | Reference.t()} | nil,
           links: %{String.t() => Link.t() | Reference.t()} | nil,
-          callbacks: %{String.t() => Callback.t() | Reference.t()} | nil
+          callbacks: %{String.t() => Callback.t() | Reference.t()} | nil,
+          extensions: %{String.t() => any()} | nil
         }
 end

--- a/lib/open_api_spex/contact.ex
+++ b/lib/open_api_spex/contact.ex
@@ -6,7 +6,8 @@ defmodule OpenApiSpex.Contact do
   defstruct [
     :name,
     :url,
-    :email
+    :email,
+    extensions: nil
   ]
 
   @typedoc """
@@ -17,6 +18,7 @@ defmodule OpenApiSpex.Contact do
   @type t :: %__MODULE__{
           name: String.t() | nil,
           url: String.t() | nil,
-          email: String.t() | nil
+          email: String.t() | nil,
+          extensions: %{String.t() => any()} | nil
         }
 end

--- a/lib/open_api_spex/discriminator.ex
+++ b/lib/open_api_spex/discriminator.ex
@@ -8,7 +8,8 @@ defmodule OpenApiSpex.Discriminator do
   @enforce_keys :propertyName
   defstruct [
     :propertyName,
-    :mapping
+    :mapping,
+    :extensions
   ]
 
   @typedoc """
@@ -21,7 +22,8 @@ defmodule OpenApiSpex.Discriminator do
   """
   @type t :: %__MODULE__{
           propertyName: String.t(),
-          mapping: %{String.t() => String.t()} | nil
+          mapping: %{String.t() => String.t()} | nil,
+          extensions: %{String.t() => any()} | nil
         }
 
   @doc """

--- a/lib/open_api_spex/encoding.ex
+++ b/lib/open_api_spex/encoding.ex
@@ -9,7 +9,8 @@ defmodule OpenApiSpex.Encoding do
     :headers,
     :style,
     :explode,
-    :allowReserved
+    :allowReserved,
+    :extensions
   ]
 
   @typedoc """
@@ -22,6 +23,7 @@ defmodule OpenApiSpex.Encoding do
           headers: %{String.t() => Header.t() | Reference.t()} | nil,
           style: Parameter.style() | nil,
           explode: boolean | nil,
-          allowReserved: boolean | nil
+          allowReserved: boolean | nil,
+          extensions: %{String.t() => any()} | nil
         }
 end

--- a/lib/open_api_spex/example.ex
+++ b/lib/open_api_spex/example.ex
@@ -6,7 +6,8 @@ defmodule OpenApiSpex.Example do
     :summary,
     :description,
     :value,
-    :externalValue
+    :externalValue,
+    :extensions
   ]
 
   @typedoc """
@@ -18,6 +19,7 @@ defmodule OpenApiSpex.Example do
           summary: String.t() | nil,
           description: String.t() | nil,
           value: any,
-          externalValue: String.t() | nil
+          externalValue: String.t() | nil,
+          extensions: %{String.t() => any()} | nil
         }
 end

--- a/lib/open_api_spex/extendable.ex
+++ b/lib/open_api_spex/extendable.ex
@@ -9,14 +9,31 @@ end
 
 defimpl OpenApiSpex.Extendable,
   for: [
+    OpenApiSpex.Components,
+    OpenApiSpex.Contact,
+    OpenApiSpex.Discriminator,
+    OpenApiSpex.Encoding,
+    OpenApiSpex.Example,
+    OpenApiSpex.ExternalDocumentation,
+    OpenApiSpex.Header,
     OpenApiSpex.Info,
+    OpenApiSpex.License,
+    OpenApiSpex.Link,
+    OpenApiSpex.MediaType,
+    OpenApiSpex.OAuthFlow,
+    OpenApiSpex.OAuthFlows,
     OpenApiSpex.OpenApi,
     OpenApiSpex.Operation,
     OpenApiSpex.Parameter,
     OpenApiSpex.PathItem,
+    OpenApiSpex.RequestBody,
     OpenApiSpex.Response,
+    OpenApiSpex.Schema,
     OpenApiSpex.SecurityScheme,
-    OpenApiSpex.Tag
+    OpenApiSpex.Server,
+    OpenApiSpex.ServerVariable,
+    OpenApiSpex.Tag,
+    OpenApiSpex.Xml
   ] do
   def to_map(struct = %{extensions: e}) do
     struct

--- a/lib/open_api_spex/external_documentation.ex
+++ b/lib/open_api_spex/external_documentation.ex
@@ -6,7 +6,8 @@ defmodule OpenApiSpex.ExternalDocumentation do
   @enforce_keys :url
   defstruct [
     :description,
-    :url
+    :url,
+    :extensions
   ]
 
   @typedoc """
@@ -16,6 +17,7 @@ defmodule OpenApiSpex.ExternalDocumentation do
   """
   @type t :: %__MODULE__{
           description: String.t() | nil,
-          url: String.t()
+          url: String.t(),
+          extensions: %{String.t() => any()} | nil
         }
 end

--- a/lib/open_api_spex/header.ex
+++ b/lib/open_api_spex/header.ex
@@ -14,6 +14,7 @@ defmodule OpenApiSpex.Header do
     :schema,
     :example,
     :examples,
+    :extensions,
     style: :simple
   ]
 
@@ -35,6 +36,7 @@ defmodule OpenApiSpex.Header do
           explode: boolean | nil,
           schema: Schema.t() | Reference.t() | nil,
           example: any,
-          examples: %{String.t() => Example.t() | Reference.t()} | nil
+          examples: %{String.t() => Example.t() | Reference.t()} | nil,
+          extensions: %{String.t() => any()} | nil
         }
 end

--- a/lib/open_api_spex/license.ex
+++ b/lib/open_api_spex/license.ex
@@ -6,7 +6,8 @@ defmodule OpenApiSpex.License do
   @enforce_keys :name
   defstruct [
     :name,
-    :url
+    :url,
+    :extensions
   ]
 
   @typedoc """
@@ -16,6 +17,7 @@ defmodule OpenApiSpex.License do
   """
   @type t :: %__MODULE__{
           name: String.t(),
-          url: String.t() | nil
+          url: String.t() | nil,
+          extensions: %{String.t() => any()} | nil
         }
 end

--- a/lib/open_api_spex/link.ex
+++ b/lib/open_api_spex/link.ex
@@ -10,7 +10,8 @@ defmodule OpenApiSpex.Link do
     :parameters,
     :requestBody,
     :description,
-    :server
+    :server,
+    :extensions
   ]
 
   @typedoc """
@@ -34,6 +35,7 @@ defmodule OpenApiSpex.Link do
           parameters: %{String.t() => any} | nil,
           requestBody: any,
           description: String.t() | nil,
-          server: Server.t() | nil
+          server: Server.t() | nil,
+          extensions: %{String.t() => any()} | nil
         }
 end

--- a/lib/open_api_spex/media_type.ex
+++ b/lib/open_api_spex/media_type.ex
@@ -8,7 +8,8 @@ defmodule OpenApiSpex.MediaType do
     :schema,
     :example,
     :examples,
-    :encoding
+    :encoding,
+    :extensions
   ]
 
   @typedoc """
@@ -20,6 +21,7 @@ defmodule OpenApiSpex.MediaType do
           schema: Schema.t() | Reference.t() | nil,
           example: any,
           examples: %{String.t() => Example.t() | Reference.t()} | nil,
-          encoding: %{String => Encoding.t()} | nil
+          encoding: %{String => Encoding.t()} | nil,
+          extensions: %{String.t() => any()} | nil
         }
 end

--- a/lib/open_api_spex/oauth_flow.ex
+++ b/lib/open_api_spex/oauth_flow.ex
@@ -6,7 +6,8 @@ defmodule OpenApiSpex.OAuthFlow do
     :authorizationUrl,
     :tokenUrl,
     :refreshUrl,
-    :scopes
+    :scopes,
+    :extensions
   ]
 
   @typedoc """
@@ -18,6 +19,7 @@ defmodule OpenApiSpex.OAuthFlow do
           authorizationUrl: String.t() | nil,
           tokenUrl: String.t() | nil,
           refreshUrl: String.t() | nil,
-          scopes: %{String.t() => String.t()} | nil
+          scopes: %{String.t() => String.t()} | nil,
+          extensions: %{String.t() => any()} | nil
         }
 end

--- a/lib/open_api_spex/oauth_flows.ex
+++ b/lib/open_api_spex/oauth_flows.ex
@@ -8,7 +8,8 @@ defmodule OpenApiSpex.OAuthFlows do
     :implicit,
     :password,
     :clientCredentials,
-    :authorizationCode
+    :authorizationCode,
+    :extensions
   ]
 
   @typedoc """
@@ -20,6 +21,7 @@ defmodule OpenApiSpex.OAuthFlows do
           implicit: OAuthFlow.t() | nil,
           password: OAuthFlow.t() | nil,
           clientCredentials: OAuthFlow.t() | nil,
-          authorizationCode: OAuthFlow.t() | nil
+          authorizationCode: OAuthFlow.t() | nil,
+          extensions: %{String.t() => any()} | nil
         }
 end

--- a/lib/open_api_spex/open_api/decode.ex
+++ b/lib/open_api_spex/open_api/decode.ex
@@ -30,6 +30,8 @@ defmodule OpenApiSpex.OpenApi.Decode do
     Xml
   }
 
+  @open_api_spex_extensions ["x-struct", "x-validate"]
+
   def decode(%{"openapi" => _openapi, "info" => _info, "paths" => _paths} = map) do
     map
     |> to_struct(OpenApi)
@@ -163,6 +165,7 @@ defmodule OpenApiSpex.OpenApi.Decode do
     |> prop_to_struct(:securitySchemes, SecuritySchemes)
     |> prop_to_struct(:links, Links)
     |> prop_to_struct(:callbacks, Callbacks)
+    |> add_extensions(map)
   end
 
   defp to_struct(map, Link) do
@@ -171,6 +174,7 @@ defmodule OpenApiSpex.OpenApi.Decode do
     |> prop_to_struct(:server, Server)
     |> prop_to_struct(:requestBody, RequestBody)
     |> prop_to_struct(:parameters, Parameters)
+    |> add_extensions(map)
   end
 
   defp to_struct(map, Links), do: embedded_ref_or_struct(map, Link)
@@ -185,7 +189,9 @@ defmodule OpenApiSpex.OpenApi.Decode do
   defp to_struct(map, SecuritySchemes), do: embedded_ref_or_struct(map, SecurityScheme)
 
   defp to_struct(map, OAuthFlow) do
-    struct_from_map(OAuthFlow, map)
+    OAuthFlow
+    |> struct_from_map(map)
+    |> add_extensions(map)
   end
 
   defp to_struct(map, OAuthFlows) do
@@ -195,6 +201,7 @@ defmodule OpenApiSpex.OpenApi.Decode do
     |> prop_to_struct(:password, OAuthFlow)
     |> prop_to_struct(:clientCredentials, OAuthFlow)
     |> prop_to_struct(:authorizationCode, OAuthFlow)
+    |> add_extensions(map)
   end
 
   defp to_struct(%{"$ref" => _} = map, Schema), do: struct_from_map(Reference, map)
@@ -205,6 +212,7 @@ defmodule OpenApiSpex.OpenApi.Decode do
     |> prepare_schema()
     |> (&struct_from_map(Schema, &1)).()
     |> prop_to_struct(:xml, Xml)
+    |> add_extensions(map)
   end
 
   defp to_struct(%{"type" => "array"} = map, Schema) do
@@ -213,6 +221,7 @@ defmodule OpenApiSpex.OpenApi.Decode do
     |> (&struct_from_map(Schema, &1)).()
     |> prop_to_struct(:items, Schema)
     |> prop_to_struct(:xml, Xml)
+    |> add_extensions(map)
   end
 
   defp to_struct(%{"type" => "object"} = map, Schema) do
@@ -228,6 +237,7 @@ defmodule OpenApiSpex.OpenApi.Decode do
     |> prop_to_struct(:properties, Schemas)
     |> manage_additional_properties()
     |> prop_to_struct(:externalDocs, ExternalDocumentation)
+    |> add_extensions(map)
   end
 
   defp to_struct(%{"anyOf" => _valid_schemas} = map, Schema) do
@@ -235,6 +245,7 @@ defmodule OpenApiSpex.OpenApi.Decode do
     |> struct_from_map(map)
     |> prop_to_struct(:anyOf, Schemas)
     |> prop_to_struct(:discriminator, Discriminator)
+    |> add_extensions(map)
   end
 
   defp to_struct(%{"oneOf" => _valid_schemas} = map, Schema) do
@@ -242,6 +253,7 @@ defmodule OpenApiSpex.OpenApi.Decode do
     |> struct_from_map(map)
     |> prop_to_struct(:oneOf, Schemas)
     |> prop_to_struct(:discriminator, Discriminator)
+    |> add_extensions(map)
   end
 
   defp to_struct(%{"allOf" => _valid_schemas} = map, Schema) do
@@ -249,20 +261,18 @@ defmodule OpenApiSpex.OpenApi.Decode do
     |> struct_from_map(map)
     |> prop_to_struct(:allOf, Schemas)
     |> prop_to_struct(:discriminator, Discriminator)
+    |> add_extensions(map)
   end
 
   defp to_struct(%{"not" => _valid_schemas} = map, Schema) do
     Schema
     |> struct_from_map(map)
     |> prop_to_struct(:not, Schemas)
+    |> add_extensions(map)
   end
 
   defp to_struct(map, Schemas) when is_map(map), do: embedded_ref_or_struct(map, Schema)
   defp to_struct(list, Schemas) when is_list(list), do: embedded_ref_or_struct(list, Schema)
-
-  defp to_struct(map, OAuthFlow) do
-    struct_from_map(OAuthFlow, map)
-  end
 
   defp to_struct(map, Callback) do
     map
@@ -292,6 +302,7 @@ defmodule OpenApiSpex.OpenApi.Decode do
     RequestBody
     |> struct_from_map(map)
     |> prop_to_struct(:content, Content)
+    |> add_extensions(map)
   end
 
   defp to_struct(map, RequestBodies), do: embedded_ref_or_struct(map, RequestBody)
@@ -311,7 +322,9 @@ defmodule OpenApiSpex.OpenApi.Decode do
   defp to_struct(map_or_list, Parameters), do: embedded_ref_or_struct(map_or_list, Parameter)
 
   defp to_struct(map, ServerVariable) do
-    struct_from_map(ServerVariable, map)
+    ServerVariable
+    |> struct_from_map(map)
+    |> add_extensions(map)
   end
 
   defp to_struct(map, ServerVariables) do
@@ -325,6 +338,7 @@ defmodule OpenApiSpex.OpenApi.Decode do
     Server
     |> struct_from_map(map)
     |> prop_to_struct(:variables, ServerVariables)
+    |> add_extensions(map)
   end
 
   defp to_struct(list, Servers) when is_list(list) do
@@ -348,6 +362,7 @@ defmodule OpenApiSpex.OpenApi.Decode do
     |> prop_to_struct(:examples, Examples)
     |> prop_to_struct(:encoding, Encoding)
     |> prop_to_struct(:schema, Schema)
+    |> add_extensions(map)
   end
 
   defp to_struct(map, Content) do
@@ -364,17 +379,19 @@ defmodule OpenApiSpex.OpenApi.Decode do
        Encoding
        |> struct_from_map(v)
        |> convert_value_to_atom_if_present(:style)
-       |> prop_to_struct(:headers, Headers)}
+       |> prop_to_struct(:headers, Headers)
+       |> add_extensions(v)}
     end)
   end
 
-  defp to_struct(map, Example), do: struct_from_map(Example, map)
+  defp to_struct(map, Example), do: Example |> struct_from_map(map) |> add_extensions(map)
   defp to_struct(map_or_list, Examples), do: embedded_ref_or_struct(map_or_list, Example)
 
   defp to_struct(map, Header) do
     Header
     |> struct_from_map(map)
     |> prop_to_struct(:schema, Schema)
+    |> add_extensions(map)
   end
 
   defp to_struct(map, Headers), do: embedded_ref_or_struct(map, Header)
@@ -410,6 +427,10 @@ defmodule OpenApiSpex.OpenApi.Decode do
     |> add_extensions(map)
   end
 
+  defp to_struct(map, mod)
+       when mod in [License, Contact, ExternalDocumentation, Discriminator, Xml],
+       do: mod |> struct_from_map(map) |> add_extensions(map)
+
   defp to_struct(list, mod) when is_list(list) and is_atom(mod),
     do: Enum.map(list, &to_struct(&1, mod))
 
@@ -441,7 +462,9 @@ defmodule OpenApiSpex.OpenApi.Decode do
   defp add_extensions(struct, map) do
     extensions =
       map
-      |> Enum.filter(fn {key, _val} -> String.starts_with?(key, "x-") end)
+      |> Enum.filter(fn {key, _val} ->
+        String.starts_with?(key, "x-") and key not in @open_api_spex_extensions
+      end)
       |> Map.new()
 
     Map.put(struct, :extensions, if(map_size(extensions) == 0, do: nil, else: extensions))

--- a/lib/open_api_spex/request_body.ex
+++ b/lib/open_api_spex/request_body.ex
@@ -8,6 +8,7 @@ defmodule OpenApiSpex.RequestBody do
   defstruct [
     :description,
     :content,
+    :extensions,
     required: false
   ]
 
@@ -19,6 +20,7 @@ defmodule OpenApiSpex.RequestBody do
   @type t :: %__MODULE__{
           description: String.t() | nil,
           content: %{String.t() => MediaType.t()},
-          required: boolean
+          required: boolean,
+          extensions: %{String.t() => any()} | nil
         }
 end

--- a/lib/open_api_spex/schema.ex
+++ b/lib/open_api_spex/schema.ex
@@ -184,7 +184,8 @@ defmodule OpenApiSpex.Schema do
     :example,
     :deprecated,
     :"x-struct",
-    :"x-validate"
+    :"x-validate",
+    :extensions
   ]
 
   @typedoc """
@@ -250,7 +251,8 @@ defmodule OpenApiSpex.Schema do
           example: any,
           deprecated: boolean | nil,
           "x-struct": module | nil,
-          "x-validate": module | nil
+          "x-validate": module | nil,
+          extensions: %{String.t() => any()} | nil
         }
 
   @typedoc """

--- a/lib/open_api_spex/server.ex
+++ b/lib/open_api_spex/server.ex
@@ -8,6 +8,7 @@ defmodule OpenApiSpex.Server do
   defstruct [
     :url,
     :description,
+    :extensions,
     variables: %{}
   ]
 
@@ -19,7 +20,8 @@ defmodule OpenApiSpex.Server do
   @type t :: %Server{
           url: String.t(),
           description: String.t() | nil,
-          variables: %{String.t() => ServerVariable.t()}
+          variables: %{String.t() => ServerVariable.t()},
+          extensions: %{String.t() => any()} | nil
         }
 
   @doc """

--- a/lib/open_api_spex/server_variable.ex
+++ b/lib/open_api_spex/server_variable.ex
@@ -7,7 +7,8 @@ defmodule OpenApiSpex.ServerVariable do
   defstruct [
     :enum,
     :default,
-    :description
+    :description,
+    :extensions
   ]
 
   @typedoc """
@@ -18,6 +19,7 @@ defmodule OpenApiSpex.ServerVariable do
   @type t :: %__MODULE__{
           enum: [String.t()] | nil,
           default: String.t(),
-          description: String.t() | nil
+          description: String.t() | nil,
+          extensions: %{String.t() => any()} | nil
         }
 end

--- a/lib/open_api_spex/xml.ex
+++ b/lib/open_api_spex/xml.ex
@@ -7,7 +7,8 @@ defmodule OpenApiSpex.Xml do
     :namespace,
     :prefix,
     :attribute,
-    :wrapped
+    :wrapped,
+    :extensions
   ]
 
   @typedoc """
@@ -22,6 +23,7 @@ defmodule OpenApiSpex.Xml do
           namespace: String.t() | nil,
           prefix: String.t() | nil,
           attribute: boolean | nil,
-          wrapped: boolean | nil
+          wrapped: boolean | nil,
+          extensions: %{String.t() => any()} | nil
         }
 end

--- a/test/open_api/decode_test.exs
+++ b/test/open_api/decode_test.exs
@@ -37,17 +37,22 @@ defmodule OpenApiSpex.OpenApi.DecodeTest do
                extensions: info_extensions
              } = info
 
-      assert %OpenApiSpex.Contact{} = contact
+      assert %OpenApiSpex.Contact{
+               extensions: %{"x-custom-info" => %{"codeowners" => "team-rocker"}}
+             } = contact
 
-      assert %OpenApiSpex.License{} = license
+      assert %OpenApiSpex.License{
+               extensions: %{"x-custom-info" => %{"codeowners" => "team-rocker"}}
+             } = license
 
-      assert info_extensions == %{"x-extension" => "foo"}
+      assert info_extensions == %{"x-custom-info" => %{"codeowners" => "team-rocker"}}
 
       assert %{"x-extension" => %{"value" => "haha"}} == extensions
 
       assert %OpenApiSpex.ExternalDocumentation{
                description: _,
-               url: _
+               url: _,
+               extensions: %{"x-custom-info" => %{"codeowners" => "team-rocker"}}
              } = externalDocs
 
       assert %OpenApiSpex.Components{
@@ -65,7 +70,8 @@ defmodule OpenApiSpex.OpenApi.DecodeTest do
                securitySchemes: securitySchemes,
                headers: %{
                  "api-version" => components_headers_header
-               }
+               },
+               extensions: %{"x-custom-info" => %{"codeowners" => "team-rocker"}}
              } = components
 
       assert %{
@@ -74,7 +80,8 @@ defmodule OpenApiSpex.OpenApi.DecodeTest do
                  content: %{
                    "application/json" => media_type
                  },
-                 required: false
+                 required: false,
+                 extensions: %{"x-custom-info" => %{"codeowners" => "team-rocker"}}
                }
              } = requestBodies
 
@@ -103,7 +110,8 @@ defmodule OpenApiSpex.OpenApi.DecodeTest do
                          type: :integer
                        }
                      }
-                   }
+                   },
+                   extensions: %{"x-custom-info" => %{"codeowners" => "team-rocker"}}
                  }
                },
                example: nil
@@ -145,7 +153,9 @@ defmodule OpenApiSpex.OpenApi.DecodeTest do
              } == responses
 
       assert %{
-               "foo" => %OpenApiSpex.Example{}
+               "foo" => %OpenApiSpex.Example{
+                 extensions: %{"x-custom-info" => %{"codeowners" => "team-rocker"}}
+               }
              } = examples
 
       assert %OpenApiSpex.Parameter{
@@ -158,7 +168,7 @@ defmodule OpenApiSpex.OpenApi.DecodeTest do
                  example: "gzip",
                  type: :string
                },
-               extensions: %{"x-extension" => "foo"}
+               extensions: %{"x-custom-info" => %{"codeowners" => "team-rocker"}}
              } == components_parameters_parameter
 
       assert %{
@@ -176,7 +186,8 @@ defmodule OpenApiSpex.OpenApi.DecodeTest do
                  }
                ],
                discriminator: %OpenApiSpex.Discriminator{
-                 propertyName: "userType"
+                 propertyName: "userType",
+                 extensions: %{"x-custom-info" => %{"codeowners" => "team-rocker"}}
                }
              } == admin_schema
 
@@ -194,7 +205,8 @@ defmodule OpenApiSpex.OpenApi.DecodeTest do
                  first_name: %OpenApiSpex.Schema{
                    xml: %OpenApiSpex.Xml{
                      namespace: "http://example.com/schema/sample",
-                     prefix: "sample"
+                     prefix: "sample",
+                     extensions: %{"x-custom-info" => %{"codeowners" => "team-rocker"}}
                    }
                  },
                  metadata: %OpenApiSpex.Schema{
@@ -204,7 +216,8 @@ defmodule OpenApiSpex.OpenApi.DecodeTest do
                      "$ref": "#/components/schemas/MetadataObject"
                    }
                  }
-               }
+               },
+               extensions: %{"x-custom-info" => %{"codeowners" => "team-rocker"}}
              } = user_schema
 
       assert %OpenApiSpex.Link{
@@ -227,8 +240,10 @@ defmodule OpenApiSpex.OpenApi.DecodeTest do
                server: %OpenApiSpex.Server{
                  description: "Development server",
                  url: "https://development.gigantic-server.com/v1",
-                 variables: %{}
-               }
+                 variables: %{},
+                 extensions: %{"x-custom-info" => %{"codeowners" => "team-rocker"}}
+               },
+               extensions: %{"x-custom-info" => %{"codeowners" => "team-rocker"}}
              } == link
 
       assert %{
@@ -241,11 +256,12 @@ defmodule OpenApiSpex.OpenApi.DecodeTest do
              } = petstore_auth_security_scheme
 
       assert %OpenApiSpex.SecurityScheme{
-               extensions: %{"x-extension" => "foo"}
+               extensions: %{"x-custom-info" => %{"codeowners" => "team-rocker"}}
              } = api_key_security_scheme
 
       assert %OpenApiSpex.OAuthFlows{
-               implicit: oauth_flow
+               implicit: oauth_flow,
+               extensions: %{"x-custom-info" => %{"codeowners" => "team-rocker"}}
              } = oauth_flows
 
       assert %OpenApiSpex.OAuthFlow{
@@ -255,7 +271,8 @@ defmodule OpenApiSpex.OpenApi.DecodeTest do
                scopes: %{
                  "read:pets" => "read your pets",
                  "write:pets" => "modify pets in your account"
-               }
+               },
+               extensions: %{"x-custom-info" => %{"codeowners" => "team-rocker"}}
              } = oauth_flow
 
       assert %OpenApiSpex.Header{
@@ -263,7 +280,8 @@ defmodule OpenApiSpex.OpenApi.DecodeTest do
                schema: %OpenApiSpex.Schema{
                  type: :string,
                  enum: ["beta"]
-               }
+               },
+               extensions: %{"x-custom-info" => %{"codeowners" => "team-rocker"}}
              } == components_headers_header
 
       assert [server] = servers
@@ -286,7 +304,7 @@ defmodule OpenApiSpex.OpenApi.DecodeTest do
       assert [tag] = tags
 
       assert %OpenApiSpex.Tag{
-               extensions: %{"x-extension" => "foo"},
+               extensions: %{"x-custom-info" => %{"codeowners" => "team-rocker"}},
                description: "Pets operations",
                externalDocs: %OpenApiSpex.ExternalDocumentation{
                  description: "Find more info here",
@@ -305,7 +323,7 @@ defmodule OpenApiSpex.OpenApi.DecodeTest do
                "/example" => %OpenApiSpex.PathItem{
                  summary: "/example summary",
                  description: "/example description",
-                 extensions: %{"x-extension" => "foo"},
+                 extensions: %{"x-custom-info" => %{"codeowners" => "team-rocker"}},
                  servers: [%OpenApiSpex.Server{}],
                  parameters: [
                    %OpenApiSpex.Reference{
@@ -313,7 +331,7 @@ defmodule OpenApiSpex.OpenApi.DecodeTest do
                    }
                  ],
                  post: %OpenApiSpex.Operation{
-                   extensions: %{"x-extension" => "foo"},
+                   extensions: %{"x-custom-info" => %{"codeowners" => "team-rocker"}},
                    parameters: [
                      %OpenApiSpex.Reference{},
                      %OpenApiSpex.Reference{},
@@ -358,7 +376,12 @@ defmodule OpenApiSpex.OpenApi.DecodeTest do
 
       assert %{
                "200" => %OpenApiSpex.Response{
-                 extensions: %{"x-extension" => "foo"}
+                 content: %{
+                   "application/json" => %OpenApiSpex.MediaType{
+                     extensions: %{"x-custom-info" => %{"codeowners" => "team-rocker"}}
+                   }
+                 },
+                 extensions: %{"x-custom-info" => %{"codeowners" => "team-rocker"}}
                }
              } = operationResponses
 

--- a/test/support/encoded_schema.json
+++ b/test/support/encoded_schema.json
@@ -1,14 +1,23 @@
 {
   "openapi": "3.0.0",
   "info": {
-    "contact": {},
+    "contact": {
+      "x-custom-info": {
+        "codeowners": "team-rocker"
+      }
+    },
     "description": "test description",
     "license": {
-      "name": "test"
+      "name": "test",
+      "x-custom-info": {
+        "codeowners": "team-rocker"
+      }
     },
     "title": "Duffel Technology Ltd.",
     "version": "1.0.0",
-    "x-extension": "foo"
+    "x-custom-info": {
+      "codeowners": "team-rocker"
+    }
   },
   "x-extension": {
     "value": "haha"
@@ -26,6 +35,9 @@
     }
   ],
   "components": {
+    "x-custom-info": {
+      "codeowners": "team-rocker"
+    },
     "parameters": {
       "ContentTypeHeader": {
         "name": "content-type",
@@ -45,11 +57,16 @@
           "example": "gzip",
           "type": "string"
         },
-        "x-extension": "foo"
+        "x-custom-info": {
+          "codeowners": "team-rocker"
+        }
       }
     },
     "headers": {
       "api-version": {
+        "x-custom-info": {
+          "codeowners": "team-rocker"
+        },
         "description": "The version of the api to be used",
         "schema": {
           "type": "string",
@@ -85,7 +102,9 @@
     },
     "securitySchemes": {
       "api_key": {
-        "x-extension": "foo",
+        "x-custom-info": {
+          "codeowners": "team-rocker"
+        },
         "type": "apiKey",
         "name": "api_key",
         "in": "header"
@@ -93,7 +112,13 @@
       "petstore_auth": {
         "type": "oauth2",
         "flows": {
+          "x-custom-info": {
+            "codeowners": "team-rocker"
+          },
           "implicit": {
+            "x-custom-info": {
+              "codeowners": "team-rocker"
+            },
             "authorizationUrl": "http://example.org/api/oauth/dialog",
             "scopes": {
               "write:pets": "modify pets in your account",
@@ -127,6 +152,9 @@
     },
     "schemas": {
       "User": {
+        "x-custom-info": {
+          "codeowners": "team-rocker"
+        },
         "nullable": false,
         "readOnly": false,
         "writeOnly": false,
@@ -146,7 +174,10 @@
             "type": "string",
             "xml": {
               "namespace": "http://example.com/schema/sample",
-              "prefix": "sample"
+              "prefix": "sample",
+              "x-custom-info": {
+                "codeowners": "team-rocker"
+              }
             }
           },
           "id": {
@@ -193,7 +224,10 @@
           }
         ],
         "discriminator": {
-          "propertyName": "userType"
+          "propertyName": "userType",
+          "x-custom-info": {
+            "codeowners": "team-rocker"
+          }
         }
       },
       "MetadataObject": {
@@ -227,6 +261,9 @@
     },
     "links": {
       "address": {
+        "x-custom-info": {
+          "codeowners": "team-rocker"
+        },
         "operationId": "test",
         "parameters": {
           "ContentTypeHeader": {
@@ -248,7 +285,10 @@
         },
         "server": {
           "description": "Development server",
-          "url": "https://development.gigantic-server.com/v1"
+          "url": "https://development.gigantic-server.com/v1",
+          "x-custom-info": {
+            "codeowners": "team-rocker"
+          }
         }
       }
     },
@@ -280,12 +320,18 @@
     },
     "examples": {
       "foo": {
+        "x-custom-info": {
+          "codeowners": "team-rocker"
+        },
         "summary": "A foo example",
         "value": "{\"foo\": \"bar\"}"
       }
     },
     "requestBodies": {
       "test": {
+        "x-custom-info": {
+          "codeowners": "team-rocker"
+        },
         "description": "user to add to the system",
         "content": {
           "application/json": {
@@ -300,6 +346,9 @@
             },
             "encoding": {
               "historyMetadata": {
+                "x-custom-info": {
+                  "codeowners": "team-rocker"
+                },
                 "contentType": "application/xml; charset=utf-8",
                 "allowReserved": false,
                 "explode": false,
@@ -322,11 +371,15 @@
   },
   "paths": {
     "/example": {
-      "x-extension": "foo",
+      "x-custom-info": {
+        "codeowners": "team-rocker"
+      },
       "summary": "/example summary",
       "description": "/example description",
       "post": {
-        "x-extension": "foo",
+        "x-custom-info": {
+          "codeowners": "team-rocker"
+        },
         "operationId": "example-post-test",
         "callbacks": {
           "operationCallback": {
@@ -450,9 +503,14 @@
         },
         "responses": {
           "200": {
-            "x-extension": "foo",
+            "x-custom-info": {
+              "codeowners": "team-rocker"
+            },
             "content": {
               "application/json": {
+                "x-custom-info": {
+                  "codeowners": "team-rocker"
+                },
                 "example": {
                   "first_name": "John",
                   "id": 678,
@@ -489,9 +547,14 @@
         },
         "responses": {
           "200": {
-            "x-extension": "foo",
+            "x-custom-info": {
+              "codeowners": "team-rocker"
+            },
             "content": {
               "application/json": {
+                "x-custom-info": {
+                  "codeowners": "team-rocker"
+                },
                 "example": {
                   "first_name": "John",
                   "id": 678,
@@ -551,11 +614,16 @@
         "description": "Find more info here",
         "url": "https://example.com"
       },
-      "x-extension": "foo"
+      "x-custom-info": {
+        "codeowners": "team-rocker"
+      }
     }
   ],
   "externalDocs": {
     "description": "Find more info here",
-    "url": "https://example.com"
+    "url": "https://example.com",
+    "x-custom-info": {
+      "codeowners": "team-rocker"
+    }
   }
 }


### PR DESCRIPTION
Swagger documentation is outdated (https://swagger.io/docs/specification/openapi-extensions/).

Reading OpenApi sepcification (https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md)
one can see that almost all objects can be extended with custom extensions.